### PR TITLE
Iteration5/past acttivities

### DIFF
--- a/Activity.js
+++ b/Activity.js
@@ -33,5 +33,7 @@ class Activity {
   };
 
   saveToStorage() {
+    var local = JSON.stringify(pastActivities)
+    localStorage.setItem('savedArray', local)
   };
 };

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
       <form id="defaultForm">
         <p class="select-category"> Select a category:</p>
         <div class="button-container">
-          <button class="button" id="studyButton" type="button" name="button" value="Study"> <img class="button-icon" id="study-icon" src="./assets/study.svg" alt="lightbulb" ><br>Study</button>
-          <button class="button" id="meditateButton" type="button" name="button" value="Meditate"><img class="button-icon" id="meditate-icon" src="./assets/meditate.svg" alt="lotus flower" ><br>Meditate</button>
+          <button class="button" id="studyButton" type="button" name="button" value="Study"> <img class="button-icon" id="study-icon" src="./assets/study.svg" alt="lightbulb"><br>Study</button>
+          <button class="button" id="meditateButton" type="button" name="button" value="Meditate"><img class="button-icon" id="meditate-icon" src="./assets/meditate.svg" alt="lotus flower"><br>Meditate</button>
           <button class="button" id="exerciseButton" type="button" name="button" value="Exercise"><img class="button-icon" id="exercise-icon" src="./assets/exercise.svg" alt="running shoe"><br>Exercise</button>
         </div>
         <p class="hidden" id="categoryError"><img class="warning-icon" src="./assets/warning.svg" alt="warning icon">Please select a category</p>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <section class="right-container">
       <h2>Past Activities</h2>
       <div class="card-container"></div>
-      <p class="no-activities">You haven't logged any activities yet.<br> Complete the form to the left to get started!</p>
+      <p class="no-activities hidden">You haven't logged any activities yet.<br> Complete the form to the left to get started!</p>
     </section>
 
   </main>

--- a/main.js
+++ b/main.js
@@ -139,6 +139,7 @@ function displayCard() {
   var color = currentActivity.category.toLowerCase()
   removeClass(startNewActivityForm)
   addClass(startActivityForm)
+  currentActivity.completed = true;
   pastActivities.push(currentActivity)
   currentActivity.saveToStorage();//testing this
   cardContainer.innerHTML +=

--- a/main.js
+++ b/main.js
@@ -32,6 +32,17 @@ var startNewActivityForm = document.querySelector('.start-new-activity')
 var createNewActivityButton = document.querySelector('.create-new-activity-button')
 var userInputs = document.querySelectorAll('input')
 
+// window.addEventListener("load", windowLoad);
+
+window.addEventListener('load', function () {
+  if(localStorage.length === 0) {
+    return
+  } else {
+    windowLoad()
+    addClass(defaultMessage)
+  }
+})
+
 logButton.addEventListener("click", displayCard);
 startActivityButton.addEventListener("click", startActivity);
 createNewActivityButton.addEventListener("click", function(event){
@@ -130,12 +141,13 @@ function displayCard() {
   removeClass(startNewActivityForm)
   addClass(startActivityForm)
   pastActivities.push(currentActivity)
+  saveInfo()
   cardContainer.innerHTML += 
-   `<article>
+  `<article>
       <div class="card-section">
         <p class="card-title">${currentActivity.category}</p>
         <p class="card-time">${currentActivity.minutes} MIN ${currentActivity.seconds} SECONDS</p>
-         <p class="card-description">${currentActivity.description}</p>
+        <p class="card-description">${currentActivity.description}</p>
       </div>
       <div class="card-section">
       <button class="card-category-indicator ${color}"type="button" name="button"></button>
@@ -155,14 +167,14 @@ function createNewActivity() {
   };
 };
 
-function saveActivities() {
-  localStorage.setItem("pastActivities", JSON.stringify(pastActivities))
-  // pastActivities = localStorage.getItem(JSON.parse('pastActivities'))
-};
+// function saveActivities() {
+//   localStorage.setItem("pastActivities", JSON.stringify(pastActivities));
+// };
 
-function onLoadDisplay() {
-    pastActivities = JSON.parse(localStorage.getItem("pastActivities"));
-};
+// function onLoadDisplay() {
+//     pastActivities = JSON.parse(localStorage.getItem("pastActivities"));
+//     displayCard();
+// };
 
 //When the user refreshes the page,
 // Their past activities are still displayed!
@@ -177,3 +189,36 @@ function onLoadDisplay() {
 // JSON.stringify(pastActivities)
 // localStorage.setItem("pastActivities", JSON.stringify(pastActivities))
 // pastActivities = localStorage.getItem(JSON.parse('pastActivities'))
+
+
+function saveInfo() {
+  var local = JSON.stringify(pastActivities)
+  localStorage.setItem('savedArray', local)
+}
+function windowLoad() {
+  var page = localStorage.getItem('savedArray')
+  var info = JSON.parse(page)
+  pastActivities = info
+  // console.log(pastActivities)
+  // if (pastActivities.length === 0) {
+  //   return
+  // } else {
+    loadCard(pastActivities)
+  // }
+}
+function loadCard(thing) {
+  for(var i = 0; i < thing.length; i++) {
+  var color = thing[i].category.toLowerCase()
+  cardContainer.innerHTML +=
+  `<article>
+      <div class="card-section">
+        <p class="card-title">${thing[i].category}</p>
+        <p class="card-time">${thing[i].minutes} MIN ${thing[i].seconds} SECONDS</p>
+        <p class="card-description">${thing[i].description}</p>
+      </div>
+      <div class="card-section">
+      <button class="card-category-indicator ${color}"type="button" name="button"></button>
+      </div>
+    </article>`
+  }
+}

--- a/main.js
+++ b/main.js
@@ -33,21 +33,11 @@ var createNewActivityButton = document.querySelector('.create-new-activity-butto
 var userInputs = document.querySelectorAll('input')
 
 
-window.addEventListener('load', function() {
-  if (localStorage.length === 0) {
-    return
-  } else {
-    windowLoad()
-    addClass(defaultMessage)
-  }
-})
+window.addEventListener('load', displayLocalStorage)
 
 logButton.addEventListener("click", displayCard);
 startActivityButton.addEventListener("click", startActivity);
-createNewActivityButton.addEventListener("click", function(event) {
-  event.preventDefault();
-  createNewActivity();
-});
+createNewActivityButton.addEventListener("click", window.location.reload)
 
 
 startButton.addEventListener("click", function() {
@@ -155,19 +145,6 @@ function displayCard() {
     </article>`
 };
 
-function createNewActivity() {
-  addClass(logButton)
-  addClass(startNewActivityForm)
-  removeClass(defaultForm)
-  resetButtons()
-  startButton.disabled = false
-  startButton.innerText = "START"
-  for (var i = 0; i < userInputs.length; i++) {
-    userInputs[i].value = ""
-  };
-};
-
-
 
 function windowLoad() {
   var page = localStorage.getItem('savedArray')
@@ -192,4 +169,12 @@ function loadCard(thing) {
       </div>
     </article>`
   }
+}
+
+function displayLocalStorage() {
+  if (localStorage.length === 0) {
+    removeClass(defaultMessage)
+    return
+  }
+    windowLoad()
 }

--- a/main.js
+++ b/main.js
@@ -32,10 +32,9 @@ var startNewActivityForm = document.querySelector('.start-new-activity')
 var createNewActivityButton = document.querySelector('.create-new-activity-button')
 var userInputs = document.querySelectorAll('input')
 
-// window.addEventListener("load", windowLoad);
 
-window.addEventListener('load', function () {
-  if(localStorage.length === 0) {
+window.addEventListener('load', function() {
+  if (localStorage.length === 0) {
     return
   } else {
     windowLoad()
@@ -45,7 +44,7 @@ window.addEventListener('load', function () {
 
 logButton.addEventListener("click", displayCard);
 startActivityButton.addEventListener("click", startActivity);
-createNewActivityButton.addEventListener("click", function(event){
+createNewActivityButton.addEventListener("click", function(event) {
   event.preventDefault();
   createNewActivity();
 });
@@ -58,7 +57,7 @@ startButton.addEventListener("click", function() {
 selectActivityButton.addEventListener("click", function(event) {
   var button = event.target.closest('button');
   resetButtons();
-  button.disabled = true ;
+  button.disabled = true;
   button.firstElementChild.src = `./assets/${button.value.toLowerCase()}-active.svg`;
 });
 
@@ -110,7 +109,7 @@ function checkForErrors() {
       removeClass(errorMessages[i]);
       return true;
     }
-  } 
+  }
 }
 
 function hideErrorMessages() {
@@ -129,8 +128,8 @@ function addClass(element, className) {
 }
 
 function resetButtons() {
-  for(var i = 0; i < activityButtons.length; i++) {
-    activityButtons[i].disabled = false ;
+  for (var i = 0; i < activityButtons.length; i++) {
+    activityButtons[i].disabled = false;
     activityButtons[i].firstElementChild.src = activityButtons[i].firstElementChild.src.replace('-active', "")
   };
 }
@@ -141,9 +140,9 @@ function displayCard() {
   removeClass(startNewActivityForm)
   addClass(startActivityForm)
   pastActivities.push(currentActivity)
-  saveInfo()
-  cardContainer.innerHTML += 
-  `<article>
+  currentActivity.saveToStorage();//testing this
+  cardContainer.innerHTML +=
+    `<article>
       <div class="card-section">
         <p class="card-title">${currentActivity.category}</p>
         <p class="card-time">${currentActivity.minutes} MIN ${currentActivity.seconds} SECONDS</p>
@@ -162,55 +161,26 @@ function createNewActivity() {
   resetButtons()
   startButton.disabled = false
   startButton.innerText = "START"
-  for (var i = 0; i < userInputs.length; i++){
+  for (var i = 0; i < userInputs.length; i++) {
     userInputs[i].value = ""
   };
 };
 
-// function saveActivities() {
-//   localStorage.setItem("pastActivities", JSON.stringify(pastActivities));
-// };
-
-// function onLoadDisplay() {
-//     pastActivities = JSON.parse(localStorage.getItem("pastActivities"));
-//     displayCard();
-// };
-
-//When the user refreshes the page,
-// Their past activities are still displayed!
-// Hint: localStorage could come in handy here…
-
-// -- needs:
-
-// - on window load - json.parse back to past activities to re-pop
-// - refactor displayCard function on window load?
-// -- could call in a loop to fire for each item
-
-// JSON.stringify(pastActivities)
-// localStorage.setItem("pastActivities", JSON.stringify(pastActivities))
-// pastActivities = localStorage.getItem(JSON.parse('pastActivities'))
 
 
-function saveInfo() {
-  var local = JSON.stringify(pastActivities)
-  localStorage.setItem('savedArray', local)
-}
 function windowLoad() {
   var page = localStorage.getItem('savedArray')
   var info = JSON.parse(page)
   pastActivities = info
-  // console.log(pastActivities)
-  // if (pastActivities.length === 0) {
-  //   return
-  // } else {
-    loadCard(pastActivities)
-  // }
+
+  loadCard(pastActivities)
 }
+
 function loadCard(thing) {
-  for(var i = 0; i < thing.length; i++) {
-  var color = thing[i].category.toLowerCase()
-  cardContainer.innerHTML +=
-  `<article>
+  for (var i = 0; i < thing.length; i++) {
+    var color = thing[i].category.toLowerCase()
+    cardContainer.innerHTML +=
+      `<article>
       <div class="card-section">
         <p class="card-title">${thing[i].category}</p>
         <p class="card-time">${thing[i].minutes} MIN ${thing[i].seconds} SECONDS</p>

--- a/main.js
+++ b/main.js
@@ -141,7 +141,7 @@ function displayCard() {
       <button class="card-category-indicator ${color}"type="button" name="button"></button>
       </div>
     </article>`
-}
+};
 
 function createNewActivity() {
   addClass(logButton)
@@ -152,5 +152,28 @@ function createNewActivity() {
   startButton.innerText = "START"
   for (var i = 0; i < userInputs.length; i++){
     userInputs[i].value = ""
-  }
-}
+  };
+};
+
+function saveActivities() {
+  localStorage.setItem("pastActivities", JSON.stringify(pastActivities))
+  // pastActivities = localStorage.getItem(JSON.parse('pastActivities'))
+};
+
+function onLoadDisplay() {
+    pastActivities = JSON.parse(localStorage.getItem("pastActivities"));
+};
+
+//When the user refreshes the page,
+// Their past activities are still displayed!
+// Hint: localStorage could come in handy here…
+
+// -- needs:
+
+// - on window load - json.parse back to past activities to re-pop
+// - refactor displayCard function on window load?
+// -- could call in a loop to fire for each item
+
+// JSON.stringify(pastActivities)
+// localStorage.setItem("pastActivities", JSON.stringify(pastActivities))
+// pastActivities = localStorage.getItem(JSON.parse('pastActivities'))

--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,12 @@ color: #CBC9CF;
 /* **Section left** */
 .left-container, .right-container {
     float: left;
-    height: 100%
+    height: 100%;
+    overflow: auto;
+}
+
+.right-container::-webkit-scrollbar {
+  display: none;
 }
 
 .left-container {


### PR DESCRIPTION
## Is this a fix or a feature? ⬇️

Feature

## What is the change? ⬇️

The user is now able to see their past activities, even upon page reload. Each past activity is represented by a card in the right side of the screen.

## Where should the reviewer start? ⬇️

Main.js line 36 evaluates a conditional, and then invokes the windowLoad function, which should be reviewed as well. Also, the new loadCard function should be reviewed. Activity.js also received updates to the saveToStorage method. 

## How should this be tested? ⬇️

In addition to a full regression test, the tester should ensure that past activities are displayed in the cards on the right side of the page after a refresh. Use the chrome dev tools to check that all properties are assigned to local storage correctly.



## Screenshot of functionality ⬇️
![Screen Shot 2021-01-11 at 4 36 28 PM](https://user-images.githubusercontent.com/66529559/104250609-2c63d880-542b-11eb-85fd-f4955cf3b7f1.png)